### PR TITLE
disable sign-in token when mailer disabled

### DIFF
--- a/app/controllers/concerns/sign_in_token_authentication_concern.rb
+++ b/app/controllers/concerns/sign_in_token_authentication_concern.rb
@@ -8,6 +8,7 @@ module SignInTokenAuthenticationConcern
   end
 
   def sign_in_token_required?
+    return false if Rails.configuration.x.disable_mailer
     find_user&.suspicious_sign_in?(request.remote_ip)
   end
 


### PR DESCRIPTION
0.3 changes the sign-in IP from 127.0.0.1 to 172.18.0.1. If the user has SMTP disabled and hasn't signed into their 02x Mastodon instance in over 2 weeks then migrates to 0.3, it looks like they're signing in from an IP they've never used before, which triggers a requirement to sign in using a token, which is sent out over the mailer, which of course cannot actually send an email.

This PR disables this "suspicious sign in" system when the mailer is disabled.